### PR TITLE
修复UI部分文案显示异常

### DIFF
--- a/MelodicStamp/Localizable.xcstrings
+++ b/MelodicStamp/Localizable.xcstrings
@@ -757,6 +757,23 @@
         }
       }
     },
+    "CFBundleDisplayName" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melodic Stamp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "音律纹章"
+          }
+        }
+      }
+    },
     "Chroma" : {
       "localizations" : {
         "zh-Hans" : {

--- a/MelodicStamp/Utilities/Extensions/Foundation/Bundle+Extensions.swift
+++ b/MelodicStamp/Utilities/Extensions/Foundation/Bundle+Extensions.swift
@@ -20,7 +20,7 @@ extension Bundle {
 
 extension Bundle {
     subscript(localized key: Key) -> String {
-        localizedInfoDictionary?[key.rawValue] as? String ?? "⚠️"
+        String(localized: String.LocalizationValue(key.rawValue))
     }
 
     subscript(_ key: Key) -> String {

--- a/MelodicStamp/Utilities/Extensions/Foundation/Bundle+Extensions.swift
+++ b/MelodicStamp/Utilities/Extensions/Foundation/Bundle+Extensions.swift
@@ -24,6 +24,9 @@ extension Bundle {
     }
 
     subscript(_ key: Key) -> String {
-        infoDictionary?[key.rawValue] as? String ?? "⚠️"
+        guard let infoDictionary = self.infoDictionary else {
+            return "⚠️"
+        }
+        return infoDictionary[key.rawValue] as? String ?? "⚠️"
     }
 }


### PR DESCRIPTION
1、用 String(localized:) 代替 localizedInfoDictionary
2、使用 guard 语句提高 infoDictionary 访问的安全性
3、新增CFBundleDisplayName中文和英文对应文案